### PR TITLE
메니저 기능 - 도서지기관리, 유저리스트 호출 구현

### DIFF
--- a/src/main/java/com/example/jdnc_library/domain/member/model/Member.java
+++ b/src/main/java/com/example/jdnc_library/domain/member/model/Member.java
@@ -56,4 +56,8 @@ public class Member {
         this.name = name;
         this.email = email;
     }
+
+    public void updateROLE(Role role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/example/jdnc_library/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/jdnc_library/domain/member/repository/MemberRepository.java
@@ -1,10 +1,13 @@
 package com.example.jdnc_library.domain.member.repository;
 
 import com.example.jdnc_library.domain.member.model.Member;
+import com.example.jdnc_library.domain.member.model.Role;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Member findByMbNumber(String mbNumber);
+    List<Member> findAllByRole(Role role);
 
 }

--- a/src/main/java/com/example/jdnc_library/feature/manager/controller/ManagerController.java
+++ b/src/main/java/com/example/jdnc_library/feature/manager/controller/ManagerController.java
@@ -1,0 +1,98 @@
+package com.example.jdnc_library.feature.manager.controller;
+
+import com.example.jdnc_library.domain.member.model.Member;
+import com.example.jdnc_library.feature.manager.model.MemberDTO;
+import com.example.jdnc_library.feature.manager.model.StatusNResultDTO;
+import com.example.jdnc_library.feature.manager.service.ManagerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/manager")
+public class ManagerController {
+
+    private final ManagerService managerService;
+
+    /**
+     * 모든 유저 리스트 불러오기(페이징)
+     * @param "page", "size"
+     *  -> 리스트를 size 씩 나눈것들 중에 page 번째의 값을을 호출
+     *  -> page=1, size=10 이라고 가정하면 10~19.
+     */
+    @GetMapping("/members")
+    //    @Secured("ROLE_MANAGER")
+    public ResponseEntity<?> getMemberList(Pageable pageable) {
+        StatusNResultDTO result = managerService.getMemberList(pageable);
+        if(result.isCheck()) {
+            return ResponseEntity.ok(result.getList());
+        } else {
+            return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .header("Content-Type", "text/plain")
+                .body(result.getMessage());
+        }
+    }
+
+    /**
+     * 도서지기 목록 불러오기
+     */
+    @GetMapping("/book-keeper")
+//    @Secured("ROLE_MANAGER")
+    public ResponseEntity<?> getBookKeeper() {
+        StatusNResultDTO result = managerService.getBookKeeper();
+        if(result.isCheck()) {
+            return ResponseEntity.ok(result.getList());
+        } else {
+            return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .header("Content-Type", "text/plain")
+                .body(result.getMessage());
+        }
+    }
+
+    /**
+     * 도서지기 임명
+     * @param "mbNumber"
+     */
+    @PostMapping("/book-keeper")
+//    @Secured("ROLE_MANAGER")
+    public ResponseEntity<String> setBookKeeper(@RequestBody MemberDTO bookKeeperDTO) {
+        StatusNResultDTO result = managerService.setBookKeeper(bookKeeperDTO.getMbNumber());
+
+        if (result.isCheck()) {
+            return ResponseEntity.ok(result.getMessage());
+
+        } else {
+            return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .header("Content-Type", "text/plain")
+                .body(result.getMessage());
+        }
+    }
+
+    @DeleteMapping("/book-keeper")
+//    @Secured("ROLE_MANAGER")
+    public ResponseEntity<?> deleteBookKeeper(@RequestBody MemberDTO bookKeeperDTO) {
+        StatusNResultDTO result = managerService.deleteBookKeeper(bookKeeperDTO.getMbNumber());
+
+        if (result.isCheck()) {
+            return ResponseEntity.ok(result.getMessage());
+
+        } else {
+            return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .header("Content-Type", "text/plain")
+                .body(result.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/jdnc_library/feature/manager/model/MemberDTO.java
+++ b/src/main/java/com/example/jdnc_library/feature/manager/model/MemberDTO.java
@@ -1,0 +1,21 @@
+package com.example.jdnc_library.feature.manager.model;
+
+import com.example.jdnc_library.domain.member.model.Role;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberDTO {
+    private String mbNumber;
+
+    private String name;
+
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+}

--- a/src/main/java/com/example/jdnc_library/feature/manager/model/StatusNResultDTO.java
+++ b/src/main/java/com/example/jdnc_library/feature/manager/model/StatusNResultDTO.java
@@ -1,0 +1,15 @@
+package com.example.jdnc_library.feature.manager.model;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StatusNResultDTO {
+    private boolean check;
+
+    private String message;
+
+    private List<?> list;
+}

--- a/src/main/java/com/example/jdnc_library/feature/manager/service/ManagerService.java
+++ b/src/main/java/com/example/jdnc_library/feature/manager/service/ManagerService.java
@@ -1,0 +1,115 @@
+package com.example.jdnc_library.feature.manager.service;
+
+import com.example.jdnc_library.domain.member.model.Member;
+import com.example.jdnc_library.domain.member.model.Role;
+import com.example.jdnc_library.domain.member.repository.MemberRepository;
+import com.example.jdnc_library.feature.manager.model.MemberDTO;
+import com.example.jdnc_library.feature.manager.model.StatusNResultDTO;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ManagerService {
+
+    private final MemberRepository memberRepository;
+
+
+    public StatusNResultDTO getMemberList(Pageable pageable) {
+        StatusNResultDTO newReturn = new StatusNResultDTO();
+
+        Page<Member> memberList = memberRepository.findAll(pageable);
+        if(!memberList.isEmpty()) {
+            List<MemberDTO> list = new ArrayList<>();
+            for(Member member : memberList) {
+                MemberDTO nowMember = new MemberDTO();
+                nowMember.setMbNumber(member.getMbNumber());
+                nowMember.setName(member.getName());
+                nowMember.setEmail(member.getEmail());
+                nowMember.setRole(member.getRole());
+
+                list.add(nowMember);
+            }
+
+            newReturn.setCheck(true);
+            newReturn.setList(list);
+        } else {
+            newReturn.setCheck(false);
+            newReturn.setMessage("유저가 존재하지 않습니다");
+        }
+
+        return newReturn;
+    }
+
+    public StatusNResultDTO getBookKeeper() {
+        StatusNResultDTO newReturn = new StatusNResultDTO();
+        List<Member> bookKeepers = memberRepository.findAllByRole(Role.valueOf("ROLE_BOOKKEEPER"));
+
+        if(!bookKeepers.isEmpty()) {
+            List<MemberDTO> list = new ArrayList<>();
+            for(Member bookKeeper : bookKeepers) {
+                MemberDTO bookKeeperDTO = new MemberDTO();
+                bookKeeperDTO.setMbNumber(bookKeeper.getMbNumber());
+                bookKeeperDTO.setName(bookKeeper.getName());
+                bookKeeperDTO.setEmail(bookKeeper.getEmail());
+                bookKeeperDTO.setRole(bookKeeper.getRole());
+
+                list.add(bookKeeperDTO);
+            }
+
+            newReturn.setCheck(true);
+            newReturn.setList(list);
+        } else {
+            newReturn.setCheck(false);
+            newReturn.setMessage("현재 임명된 도서지기가 없습니다");
+        }
+
+        return newReturn;
+    }
+
+    public StatusNResultDTO setBookKeeper(String mbNumber) {
+        StatusNResultDTO newReturn = new StatusNResultDTO();
+
+        Member newBookKeeper = memberRepository.findByMbNumber(mbNumber);
+        if(newBookKeeper == null) {
+            newReturn.setCheck(false);
+            newReturn.setMessage("해당 유저가 없습니다");
+            return newReturn;
+        }
+        if(!newBookKeeper.getRole().equals("ROLE_BOOKKEEPER")) {
+            newBookKeeper.updateROLE(Role.valueOf("ROLE_BOOKKEEPER"));
+            memberRepository.save(newBookKeeper);
+            newReturn.setCheck(true);
+            newReturn.setMessage("해당 유저를 도서지기로 임명하였습니다");
+        } else {
+            newReturn.setCheck(false);
+            newReturn.setMessage("해당 유저는 이미 도서지기이거나 매니저입니다");
+        }
+        return newReturn;
+    }
+
+    public StatusNResultDTO deleteBookKeeper(String mbNumber) {
+        StatusNResultDTO newReturn = new StatusNResultDTO();
+
+        Member newBookKeeper = memberRepository.findByMbNumber(mbNumber);
+        if(newBookKeeper == null) {
+            newReturn.setCheck(false);
+            newReturn.setMessage("해당 유저가 없습니다");
+            return newReturn;
+        }
+        if(newBookKeeper.getRole().equals("ROLE_BOOKKEEPER")) {
+            newBookKeeper.updateROLE(Role.valueOf("ROLE_USER"));
+            memberRepository.save(newBookKeeper);
+            newReturn.setCheck(true);
+            newReturn.setMessage("해당 유저를 일반 유저로 되돌렸습니다");
+        } else {
+            newReturn.setCheck(false);
+            newReturn.setMessage("해당 유저는 도서지기가 아닙니다");
+        }
+        return newReturn;
+    }
+}


### PR DESCRIPTION
## PR 타입
어떤 유형의 PR인지 체크해주세요.
<!-- 체크하려면 괄호 안에 “x”를 입력하세요. -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:
## PR 설명
메니저의 기능중, 도서지기의 임명, 해임, 현재 도서지기 확인 등을 구현
모든 유저의 리스트를 페이지네이션 해서 가져오는 기능 구현
## 작업사항
Member를 다루는 DTO가 아직 없어서 만들어 사용하였음. 추후 DTO의 이동 혹은 통합으로 사용할 DTO가 필요.
Secured어노테이션을 사용하여 접근 권한을 처리하였음. 현재는 비활성 상태.
응답을 status와 message / value(s)로 하고 있는데, message 의 경우 plain text로 보내고 있음. 확인 요망.

